### PR TITLE
check unique on combined fields

### DIFF
--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -215,7 +215,7 @@ module.exports.prototype = {
     return this._validateUnique(req, id, docs, fn);
   },
 
-_validateUnique: function _validateUnique(req, id, docs, fn) {
+ _validateUnique: function _validateUnique(req, id, docs, fn) {
     docs = Array.isArray(docs) ? docs : [docs];
 
     if (!docs.length) {

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -215,7 +215,7 @@ module.exports.prototype = {
     return this._validateUnique(req, id, docs, fn);
   },
 
-  _validateUnique: function _validateUnique(req, id, docs, fn) {
+_validateUnique: function _validateUnique(req, id, docs, fn) {
     docs = Array.isArray(docs) ? docs : [docs];
 
     if (!docs.length) {
@@ -226,27 +226,33 @@ module.exports.prototype = {
     var conditions = [];
 
     for (var i = 0; i < uniqueFields.length; i++) {
-      var key = uniqueFields[i];
+      var keys = uniqueFields[i].split('&');
+      var subCondition = { };
 
-      if (!!this._model.schema.paths[key]) {
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
 
-        var values = docs.map(function (doc) {
-          var val = doc[key];
-          val = val && mongoose.Types.ObjectId.isValid(val.toString()) ? $.utils.getId(val) : val;
-          return val;
-        }).filter(function (val) {
-          return !!val;
-        });
+        if (!!this._model.schema.paths[key]) {
 
-        // Check if the list itself contains duplicates, otherwise return immediately
-        for (var j = 0; j < values.length; j++) {
-          if (values.indexOf(values[j]) !== values.lastIndexOf(values[j])) {
-            return fn('duplicate_unique_fields');
+          var values = docs.map(function (doc) {
+            var val = doc[key];
+            val = val && mongoose.Types.ObjectId.isValid(val.toString()) ? $.utils.getId(val) : val;
+            return val;
+          }).filter(function (val) {
+            return !!val;
+          });
+
+          // Check if the list itself contains duplicates, otherwise return immediately
+          for (var k = 0; k < values.length; k++) {
+            if (values.indexOf(values[k]) !== values.lastIndexOf(values[k])) {
+              return fn('duplicate_unique_fields');
+            }
           }
-        }
 
-        conditions[conditions.push({}) - 1][key] = { $in: values };
+          subCondition[key] = { $in: values }
+        }
       }
+      conditions.push(subCondition)
     }
 
     conditions = { $or: conditions };


### PR DESCRIPTION
When this is merged, unique fields can be defined like this:
uniqueFields:           'email username firstname&lastname',
then the combination of firstname & lastname should be unique.

The original idea was targeted towards the nested set - only check for uniqueness among siblings so we can extend the service using this:
uniqueFields: 'name&parentId'